### PR TITLE
Disabled IPv6 by default

### DIFF
--- a/src/Facebook/HttpClients/FacebookCurlHttpClient.php
+++ b/src/Facebook/HttpClients/FacebookCurlHttpClient.php
@@ -70,7 +70,7 @@ class FacebookCurlHttpClient implements FacebookHttpable
   /**
    * @var boolean If IPv6 should be disabled
    */
-  protected static $disableIPv6;
+  protected static $disableIPv6 = true;
 
   /**
    * @const Curl Version which is unaffected by the proxy header length error.


### PR DESCRIPTION
To prevent `Facebook\FacebookSDKException` with message `Failed to connect to 2a03:2880:f01f:2:face:b00c:0:2: Network is unreachable`.
